### PR TITLE
Allow build on stable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
 language: rust
 rust:
+  - stable
   - nightly

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,6 @@ travis-ci = { repository = "synek317/test-case-derive", branch = "master" }
 maintenance = { status = "actively-developed" }
 
 [lib]
-doctest = false
 proc-macro = true
 path = "src/lib.rs"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 license = "MIT"
 repository = "https://github.com/synek317/test-case-derive"
 documentation = "https://docs.rs/test-case-derive"
+build = "build.rs"
 
 [badges]
 travis-ci = { repository = "synek317/test-case-derive", branch = "master" }
@@ -18,6 +19,9 @@ maintenance = { status = "actively-developed" }
 doctest = false
 proc-macro = true
 path = "src/lib.rs"
+
+[build-dependencies]
+version_check = "0.1.5"
 
 [dependencies]
 syn = "0.11.11"

--- a/README.md
+++ b/README.md
@@ -20,32 +20,17 @@ First of all you have to add this dependency to your `Cargo.toml`:
 test-case-derive = "0.2.0"
 ```
 
-Additionally you have to enable `proc_macro` feature and include crate. You can do this globally by adding:
+Additionally you have to import the procedural macro with `use` statement:
 
-```
-#![feature(proc_macro)]
-extern crate test_case_derive;
-```
-
-to your `lib.rs` or `main.rs` file. Optionally you may enable proc macros only for tests:
-
-```
-#![cfg_attr(test, feature(proc_macro))]
-#[cfg(test)]
-extern crate test_case_derive;
-```
-
-Don't forget that procedural macros are imported with `use` statement:
-
-```
+```rust
 use test_case_derive::test_case;
 ```
 
+The crate depends on `proc_macro` feature that has been stabilized on rustc 1.29+.
+
 # Example usage:
 
-```
-#![cfg(test)]
-#![feature(proc_macro)]
+```rust
 extern crate test_case_derive;
 
 use test_case_derive::test_case;
@@ -62,7 +47,7 @@ fn multiplication_tests(x: i8, y: i8) {
 
 Output from `cargo test` for this example:
 
-```
+```sh
 $ cargo test
 
 running 3 tests
@@ -77,7 +62,7 @@ test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
 
 If your only assertion is just `assert_eq!`, you can pass the expectation as macro attribute using `=>` syntax:
 
-```
+```rust
 #[test_case( 2 => 2 :: "returns given number for positive input")]
 #[test_case(-2 => 2 :: "returns opposite number for non-positive input")]
 #[test_case( 0 => 0 :: "returns 0 for 0")]
@@ -88,7 +73,7 @@ fn abs_tests(x: i8) -> i8 {
 
 Which is equivalent to
 
-```
+```rust
 #[test_case( 2, 2 :: "returns given number for positive input")]
 #[test_case(-2, 2 :: "returns opposite number for non-positive input")]
 #[test_case( 0, 0 :: "returns 0 for 0")]
@@ -101,7 +86,7 @@ fn abs_tests(x: i8, expected: i8){
 
 Attributes and expectation may be any expresion unless they contain `=>`, e.g.
 
-```
+```rust
 #[test_case(None,        None    => 0 :: "treats none as 0")]
 #[test_case(Some(2),     Some(3) => 5)]
 #[test_case(Some(2 + 3), Some(4) => 2 + 3 + 4)]
@@ -116,7 +101,7 @@ Test case names are optional. They are set using `::` followed by string literal
 
 Example generated code:
 
-```
+```rust
 mod fancy_addition {
     #[allow(unused_imports)]
     use super::*;
@@ -151,11 +136,11 @@ mod fancy_addition {
 }
 ```
 
-## Inconclusive (ignored) test cases (sicne 0.2.0)
+## Inconclusive (ignored) test cases (since 0.2.0)
 
 If test case name (passed using `::` syntax described above) contains word "inconclusive", generated test will be marked with `#[ignore]`.
 
-```
+```rust
 #[test_case("42")]
 #[test_case("XX" :: "inconclusive - parsing letters temporarily doesn't work but it's ok")]
 fn parses_input(input: &str) {
@@ -164,7 +149,7 @@ fn parses_input(input: &str) {
 ```
 
 Generated code:
-```
+```rust
 mod parses_input {
     // ...
 

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,12 @@
+use std::process::exit;
+
+fn main() {
+    match version_check::is_min_version("1.29") {
+        Some((true, _)) => {}
+        _ => {
+            // rustc version too small or can't figure it out
+            eprintln!("rustc>=1.29 is required due to feature(proc_macro) stabilitation");
+            exit(1);
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,32 +20,17 @@
 //! test-case-derive = "0.2.0"
 //! ```
 //!
-//! Additionally you have to enable `proc_macro` feature and include crate. You can do this globally by adding:
+//! Additionally you have to import the procedural macro with `use` statement:
 //!
-//! ```
-//! #![feature(proc_macro)]
-//! extern crate test_case_derive;
-//! ```
-//!
-//! to your `lib.rs` or `main.rs` file. Optionally you may enable proc macros only for tests:
-//!
-//! ```
-//! #![cfg_attr(test, feature(proc_macro))]
-//! #[cfg(test)]
-//! extern crate test_case_derive;
-//! ```
-//!
-//! Don't forget that procedural macros are imported with `use` statement:
-//!
-//! ```
+//! ```rust
 //! use test_case_derive::test_case;
 //! ```
 //!
+//! The crate depends on `proc_macro` feature that has been stabilized on rustc 1.29+.
+//!
 //! # Example usage:
 //!
-//! ```
-//! #![cfg(test)]
-//! #![feature(proc_macro)]
+//! ```rust
 //! extern crate test_case_derive;
 //!
 //! use test_case_derive::test_case;
@@ -62,7 +47,7 @@
 //!
 //! Output from `cargo test` for this example:
 //!
-//! ```
+//! ```sh
 //! $ cargo test
 //!
 //! running 3 tests
@@ -77,7 +62,7 @@
 //!
 //! If your only assertion is just `assert_eq!`, you can pass the expectation as macro attribute using `=>` syntax:
 //!
-//! ```
+//! ```rust
 //! #[test_case( 2 => 2 :: "returns given number for positive input")]
 //! #[test_case(-2 => 2 :: "returns opposite number for non-positive input")]
 //! #[test_case( 0 => 0 :: "returns 0 for 0")]
@@ -88,7 +73,7 @@
 //!
 //! Which is equivalent to
 //!
-//! ```
+//! ```rust
 //! #[test_case( 2, 2 :: "returns given number for positive input")]
 //! #[test_case(-2, 2 :: "returns opposite number for non-positive input")]
 //! #[test_case( 0, 0 :: "returns 0 for 0")]
@@ -101,7 +86,7 @@
 //!
 //! Attributes and expectation may be any expresion unless they contain `=>`, e.g.
 //!
-//! ```
+//! ```rust
 //! #[test_case(None,        None    => 0 :: "treats none as 0")]
 //! #[test_case(Some(2),     Some(3) => 5)]
 //! #[test_case(Some(2 + 3), Some(4) => 2 + 3 + 4)]
@@ -116,7 +101,7 @@
 //!
 //! Example generated code:
 //!
-//! ```
+//! ```rust
 //! mod fancy_addition {
 //!     #[allow(unused_imports)]
 //!     use super::*;
@@ -155,7 +140,7 @@
 //!
 //! If test case name (passed using `::` syntax described above) contains word "inconclusive", generated test will be marked with `#[ignore]`.
 //!
-//! ```
+//! ```rust
 //! #[test_case("42")]
 //! #[test_case("XX" :: "inconclusive - parsing letters temporarily doesn't work but it's ok")]
 //! fn parses_input(input: &str) {
@@ -164,7 +149,7 @@
 //! ```
 //!
 //! Generated code:
-//! ```
+//! ```rust
 //! mod parses_input {
 //!     // ...
 //!
@@ -210,8 +195,6 @@
 //! LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 //! OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 //! SOFTWARE.
-
-#![feature(proc_macro)]
 
 #[macro_use]
 extern crate lazy_static;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,6 +63,7 @@
 //! If your only assertion is just `assert_eq!`, you can pass the expectation as macro attribute using `=>` syntax:
 //!
 //! ```rust
+//! # use test_case_derive::test_case;
 //! #[test_case( 2 => 2 :: "returns given number for positive input")]
 //! #[test_case(-2 => 2 :: "returns opposite number for non-positive input")]
 //! #[test_case( 0 => 0 :: "returns 0 for 0")]
@@ -74,6 +75,7 @@
 //! Which is equivalent to
 //!
 //! ```rust
+//! # use test_case_derive::test_case;
 //! #[test_case( 2, 2 :: "returns given number for positive input")]
 //! #[test_case(-2, 2 :: "returns opposite number for non-positive input")]
 //! #[test_case( 0, 0 :: "returns 0 for 0")]
@@ -87,6 +89,7 @@
 //! Attributes and expectation may be any expresion unless they contain `=>`, e.g.
 //!
 //! ```rust
+//! # use test_case_derive::test_case;
 //! #[test_case(None,        None    => 0 :: "treats none as 0")]
 //! #[test_case(Some(2),     Some(3) => 5)]
 //! #[test_case(Some(2 + 3), Some(4) => 2 + 3 + 4)]
@@ -141,6 +144,7 @@
 //! If test case name (passed using `::` syntax described above) contains word "inconclusive", generated test will be marked with `#[ignore]`.
 //!
 //! ```rust
+//! # use test_case_derive::test_case;
 //! #[test_case("42")]
 //! #[test_case("XX" :: "inconclusive - parsing letters temporarily doesn't work but it's ok")]
 //! fn parses_input(input: &str) {
@@ -149,7 +153,7 @@
 //! ```
 //!
 //! Generated code:
-//! ```rust
+//! ```ignore
 //! mod parses_input {
 //!     // ...
 //!
@@ -226,6 +230,7 @@ use prelude::*;
 /// - Without result and name
 ///
 /// ```
+/// # use test_case_derive::test_case;
 /// #[test_case(5)]
 /// #[test_case(10)]
 /// fn is_positive(x: i8) {
@@ -236,6 +241,7 @@ use prelude::*;
 /// - With name, without result
 ///
 /// ```
+/// # use test_case_derive::test_case;
 /// #[test_case(1   :: "little number")]
 /// #[test_case(100 :: "big number")]
 /// #[test_case(5)] // some tests may use default name generated from arguments list
@@ -247,6 +253,7 @@ use prelude::*;
 /// - With result, without name
 ///
 /// ```
+/// # use test_case_derive::test_case;
 /// #[test_case(1,   2 =>  3)]
 /// #[test_case(-1, -2 => -3)]
 /// fn addition(x: i8, y: i8) -> i8 {
@@ -257,6 +264,7 @@ use prelude::*;
 /// - With result and name
 ///
 /// ```
+/// # use test_case_derive::test_case;
 /// #[test_case(1,   2 =>  3 :: "both numbers possitive")]
 /// #[test_case(-1, -2 => -3 :: "both numbers negative")]
 /// fn addition(x: i8, y: i8) -> i8 {

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,6 +1,5 @@
 pub use std::str::FromStr;
 pub use std::collections::HashSet;
-pub use std::ascii::AsciiExt;
 
 pub use syn::Token::{
     self, 

--- a/src/utils/escape_ident.rs
+++ b/src/utils/escape_ident.rs
@@ -3,7 +3,7 @@ use prelude::*;
 pub fn escape_ident<S: AsRef<str>>(raw: S) -> Token {
     let mut escaped = escape_chars(raw);
 
-    escaped.trim_right_matches('_');
+    let _ = escaped.trim_end_matches('_');
 
     if escaped.is_rust_keyword() || escaped.starts_with(is_digit) {
         escaped = "_".to_string() + &escaped

--- a/tests/test_cases.rs
+++ b/tests/test_cases.rs
@@ -1,6 +1,3 @@
-#![cfg(test)]
-#![feature(proc_macro)]
-
 extern crate test_case_derive;
 
 mod test_cases {


### PR DESCRIPTION
The main goal of this PR is to ensure that the library could be used on stable release.

In order to achieve so I removed the explicit request for the `proc_macro` feature gate as it has been stabilised in rustc 1.29; the presence of such gate would cause `cargo +stable build` to fail.

To prevent regressions I made sure that:
 * tests will be continuously run on stable and nightly releases
 * documentation is tested (so we can guarantee that the provided examples are actually working)